### PR TITLE
Web Application on Android and iOS

### DIFF
--- a/www/html/runtimes/index.html
+++ b/www/html/runtimes/index.html
@@ -2,6 +2,8 @@
 <html><head>
 <title>Tonyu System 2</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-capable" content="yes">
 <script src="js/lib/jquery-1.10.1.js" type="text/javascript" data-nocat="true"></script>
 <script src="js/files.js"></script>
 <script src="js/runScript2_concat.js"></script>


### PR DESCRIPTION
Android, iOSで、ゲームページをブラウザの「ホームへ追加」機能を使うことで、ホームにゲームページへのリンクとなるアイコンができる。
そのアイコンを起動すると、通常はブラウザの新規タブを開くのと同じ動作となる。

今回の対応を入れることで、ブラウザのヘッダが非表示になり１つのアプリのような表示となる。
![screenshot_2017-11-14-00-53-17_2](https://user-images.githubusercontent.com/10994913/32742929-34ae0220-c8ee-11e7-8721-2136e3dd94fb.png)
![img_2430_2](https://user-images.githubusercontent.com/10994913/32742958-466194be-c8ee-11e7-9f34-885bcdfa58ae.png)

