### PR TITLE
Fix cannot touchend bug

### DIFF
--- a/www/Kernel/ui/InputDevice.tonyu
+++ b/www/Kernel/ui/InputDevice.tonyu
@@ -190,6 +190,7 @@ native T2MediaLib;
         cvj.on("touchstart",handleTouchStart);
         cvj.on("touchmove",handleTouchMove);
         cvj.on("touchend",handleTouchEnd);
+        cvj.on("touchcancel",handleTouchEnd);
     }
 }
 


### PR DESCRIPTION
たまにスクリーンタッチを離しても検知できず、押しっぱなしと認識されるバグを修正
touchcancelイベントが発生したときにtouchendが発生しないのが原因。

touchcancelイベントを追加。
スマホ等で、タッチを押しながらホームボタンを押すと、touchendが発生せずtouchcancelが発生する。
それ以外でもtouchcancelになる場合があるため、touchcancelが起きたらtouchendと同じ処理をするようにした。