### PR TITLE
Fix bug that screen scale up on smartphone and tablet

### DIFF
--- a/www/html/runtimes/index.html
+++ b/www/html/runtimes/index.html
@@ -4,6 +4,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="viewport" content="user-scalable=no">
 <script src="js/lib/jquery-1.10.1.js" type="text/javascript" data-nocat="true"></script>
 <script src="js/files.js"></script>
 <script src="js/runScript2_concat.js"></script>


### PR DESCRIPTION
AndroidのChromeで、ゲーム開始前やゲームの処理が重い時などに連打タップすると、画面が拡大（ズーム）してゲーム画面がはみ出てしまうバグを修正。

【原因】
ブラウザでダブルタップすると画面拡大（ズーム）する仕様があり、上記タイミングで拡大処理が働くことがある。
一度拡大するとWebページをBackするまでズームを元に戻せない。（リロードでもズームした状態のままになる）

【対処】
ズームを不可にするmetaタグを追加した。