### PR TITLE
Change default FPS 30 -> 60

### DIFF
--- a/www/Kernel/Boot.tonyu
+++ b/www/Kernel/Boot.tonyu
@@ -396,7 +396,7 @@ nowait \afterDraw(drawn) {// should call (after draw) or (move and frame skip)
 }
 nowait \initFPSParams() {
     // フレームレートの設定
-    _fps = 30;
+    _fps = 60;
     maxFrameSkip = 5;
     minFrameSkip = 1;
     // フレームレート制御でつかう変数 //


### PR DESCRIPTION
フレームレートのデフォルト値を30から60に変更

そろそろ性能の高い環境が増えてきた頃合いで、60FPSでも問題無いと思いプルリクしました。

- と言いつつ、性能の低いAndroid端末やタブレットPC等では、処理落ちしやすいかもしれない
- 一般的な性能を持ったPCやiOS端末では、60FPSで問題無い

これを適用すると、今まで30FPSで作っていたゲームが60FPSで動いてしまうので、
注意喚起が必要かもしれません。
「今バージョンから、フレームレート（FPS）を30から60に変更しました。今までよりも動作速度が速くなるので（２倍速）、元の動作速度に戻したい場合は[$Boot.setFrameRate(30);](https://github.com/hoge1e3/Tonyu2/wiki/setFrameRate)のように設定してください。」等