### PR TITLE
Change touches

### DIFF
--- a/www/Kernel/ui/InputDevice.tonyu
+++ b/www/Kernel/ui/InputDevice.tonyu
@@ -19,6 +19,13 @@ native T2MediaLib;
 \newTouch(i) {
     return {index:i,px:0,py:0,x:0,y:0,vx:0,vy:0,touched:0,identifier:-1,ended:false,layer:defaultLayer};
 }
+\resetTouch(t) {
+    t.px=t.py=t.x=t.y=t.vx=t.vy=t.touched=0;
+    t.identifier=-1;
+    t.ended=false;
+    t.layer=defaultLayer;
+    return t;
+}
 \changeTouchLayer(t,toLayer) {
     var p=$Screen.convert(t,toLayer);
     t.x=p.x;
@@ -171,7 +178,7 @@ native T2MediaLib;
             var src=ts[i];
             var dst=$touches.findById(src.identifier);
             if (dst) {
-                $touches[dst.index]=$InputDevice.newTouch(dst.index);
+                $touches[dst.index]=$InputDevice.resetTouch(dst);
                 $touches[dst.index].x=dst.x;
                 $touches[dst.index].y=dst.y;
                 $touches[dst.index].layer=defaultLayer;
@@ -188,7 +195,7 @@ native T2MediaLib;
         $InputDevice.touchEmu=false;
         for (var i,t in $touches) {
             if (t.identifier==ID_MOUSE) {
-                t[i]=$InputDevice.newTouch(i);
+                t[i]=$InputDevice.resetTouch(t);
             }
         }
     };


### PR DESCRIPTION
touchesオブジェクトを再利用する。（touchesを毎回newしないようにした）

以下のようにtouchを使いまわしたとき、
カーネル側で新しいオブジェクトに置き換えられるため、
判定ができなくなる問題が発生した。
<pre>
touch=$touches[0];
actor=new Actor{p:0};
while(true){
    actor.x=$touchces.x;
    actor.y=$touchces.y;
    update();
}
</pre>

カーネル側でtouchesのオブジェクトを使いまわすようにした。