### PR TITLE
fix path in MacOS NW.js

### DIFF
--- a/www/js/lang/compiledProject.js
+++ b/www/js/lang/compiledProject.js
@@ -20,6 +20,10 @@ define(["DeferredUtil","WebSite","assert"], function (DU,WebSite,A) {
 			loadClasses: function (ctx) {
 				console.log("Loading compiled classes ns=",ns,"url=",url);
 				var src = url+(WebSite.serverType==="BA"?"?"+Math.random():"");
+				var u=window.navigator.userAgent.toLowerCase();
+				if (WebSite.isNW && u.indexOf("mac")!=-1) {
+					src = "/www/Kernel/js/concat.js";
+				}
 				var t=this;
 				return this.loadDependingClasses(ctx).then(function () {
 					return t.requirejs(src);


### PR DESCRIPTION
fix the issue, it freeze when running(F9).

Mac版開発環境で、実行(F9)するとLoadingから進まない不具合を修正。
パスの指定が適当なので、最適な指定方法があれば変更して大丈夫です。