### PR TITLE
fix $touches touchEmu bug when 

### DIFF
--- a/www/Kernel/ui/InputDevice.tonyu
+++ b/www/Kernel/ui/InputDevice.tonyu
@@ -56,7 +56,7 @@ native T2MediaLib;
                preventDefault: function (){},
                originalEvent: {
                     changedTouches: [
-                        {identifier:ID_MOUSE, pageX:e.clientX,pageY:e.clientY}
+                        {identifier:ID_MOUSE+e.button, pageX:e.clientX,pageY:e.clientY}
                     ]
                },
                byMouse: true
@@ -77,7 +77,7 @@ native T2MediaLib;
                preventDefault: function (){},
                originalEvent: {
                     changedTouches: [
-                        {identifier:ID_MOUSE, pageX:e.clientX,pageY:e.clientY}
+                        {identifier:ID_MOUSE+e.button, pageX:e.clientX,pageY:e.clientY}
                     ]
                },
                byMouse: true
@@ -97,7 +97,7 @@ native T2MediaLib;
                preventDefault: function (){},
                originalEvent: {
                     changedTouches: [
-                        {identifier:ID_MOUSE, pageX:e.clientX,pageY:e.clientY}
+                        {identifier:ID_MOUSE+e.button, pageX:e.clientX,pageY:e.clientY}
                     ]
                },
                byMouse: true


### PR DESCRIPTION
マウスボタン（左クリック・右クリック・ホイールクリックなど）を複数同時押しすると、
ボタンを離したときに$touches[].touchedがfalseにならない問題を修正。

ビルドファイルは含んでいないので、要ビルド。

Tonyu BBSで報告が上がった。
http://www.tonyu.jp/joyful/joyful.cgi?mode=res&no=13895

不具合詳細：

$touchesのマウスエミュレーション機能に不具合があり、
マウスボタン同時押しすると、touchup（タッチ解除）判定で失敗し、タッチしっぱなし状態になる。

Padクラスでは、押下判定に$touchesを使用しているので、
$touchesの不具合の影響を受けて、ボタン押しっぱなし状態となる。


マウスボタンを２つ同時押しすると、
$touches[0].touchedがtrue、
$touches[1].touchedがtrueとなる。

マウスボタンを１つ離すと、
$touches[0].touchedがtrue、
$touches[1].touchedがfalseとなる。

マウスボタンをすべて離すと、touchupの判定に失敗しているのか、
$touches[0].touchedがtrue、
$touches[1].touchedがfalseのまま。（本来どちらかがfalseになるはず）

これを繰り返すと最終的に$touches[]の0～4全てのtouchedがtureになる。