### PR TITLE
Map自動分割対応

### DIFF
--- a/www/Kernel/graphics/Map.tonyu
+++ b/www/Kernel/graphics/Map.tonyu
@@ -3,6 +3,7 @@ native Math;
 native $;
 native console;
 \new (param){
+    bufSplit=1024;
     sx=0;
     sy=0;
     alpha=255;
@@ -12,19 +13,19 @@ native console;
     if (typeof col!=="number") col=$screenWidth/chipWidth;
     if (typeof row!=="number") row=$screenHeight/chipHeight;
     col=floor(col);row=floor(row);
-    buf=$("<canvas>").attr{width:col*chipWidth,height:row*chipHeight};
+    bufAry=createBuf(col*chipWidth,row*chipHeight);
     mapObj=true;
     mapTable = [];
     mapOnTable = [];
     for(var j=0;j<row;j++){
-        rows = [];
+        var rows = [];
         for(var i=0;i<col;i++){
             rows.push(-1);
         }
         mapTable.push(rows);
     }
     for(var j=0;j<row;j++){
-        rows = [];
+        var rows = [];
         for(var i=0;i<col;i++){
             rows.push(-1);
         }
@@ -35,17 +36,35 @@ native console;
     }*/
     initMap();
 }
+\createBuf(width,height){
+    var rh=floor(height); // remaining Height
+    var ary=[];
+    for(var j=0;0<rh;j++){
+        var a=[];
+        var h=rh;
+        if(rh>bufSplit) h=bufSplit;
+        if(rh<2) h=2;
+        var rw=floor(width); // remaining Width
+        for(var i=0;0<rw;i++){
+            var w=rw;
+            if(rw>bufSplit) w=bufSplit;
+            if(rw<2) w=2;
+            a.push($("<canvas>").attr{width:w,height:h});
+            rw-=bufSplit;
+        }
+        ary.push(a);
+        rh-=bufSplit;
+    }
+    // console.log(this);
+    // console.log(ary);
+    return ary;
+}
 \initMap(){
     if(!mapData) return;
-    for(var i=0;i<row;i++){
-        for(var j=0;j<col;j++){
-            set(j,i,mapData[i][j]);
-        }
-    }
     if(!mapOnData) return;
     for(var i=0;i<row;i++){
         for(var j=0;j<col;j++){
-            setOn(j,i,mapOnData[i][j]);
+            setAll(j,i,mapData[i][j],mapOnData[i][j]);
         }
     }
 }
@@ -54,7 +73,7 @@ native console;
 }
 \redraw(){
     if(!mapTable) return;
-    buf=$("<canvas>").attr{width:col*chipWidth,height:row*chipHeight};
+    bufAry=createBuf(col*chipWidth,row*chipHeight);
     for(var i=0;i<row;i++){
         for(var j=0;j<col;j++){
             set(j,i,mapTable[i][j]);
@@ -88,7 +107,7 @@ native console;
     mapOnData=mapOnTable;
     if (baseData[2]) chipWidth=(baseData[2]-0)||chipWidth||32;
     if (baseData[3]) chipHeight=(baseData[3]-0)||chipHeight||32;
-    buf=$("<canvas>").attr{width:col*chipWidth,height:row*chipHeight};
+    bufAry=createBuf(col*chipWidth,row*chipHeight);
     initMap();
 }
 \save(saveFileName) {
@@ -96,40 +115,59 @@ native console;
     var data=[mapTable,mapOnTable,chipWidth,chipHeight];
     saveDataFile.obj(data);
 }
+\setAll(setCol,setRow,p,onP){
+    if(setCol>=col || setRow>=row || setCol<0 || setRow<0) return;
+    var oldP=mapTable[setRow][setCol];
+    var oldOnP=mapOnTable[setRow][setCol];
+    mapTable[setRow][setCol]=p;
+    mapOnTable[setRow][setCol]=onP;
+    var x1=floor(setCol*chipWidth/bufSplit);
+    var x2=floor((setCol*chipWidth+(chipWidth-1))/bufSplit);
+    var y1=floor(setRow*chipHeight/bufSplit);
+    var y2=floor((setRow*chipHeight+(chipHeight-1))/bufSplit);
+    var hs=bufAry.length;
+    for(var j=y1;j<=y2;j++){
+        var ws=bufAry[j].length;
+        for(var i=x1;i<=x2;i++){
+            var drawX = setCol*chipWidth-i*bufSplit;
+            var drawY = setRow*chipHeight-j*bufSplit;
+            var cv=bufAry[j][i];
+            if (!cv) return;
+            var ctx=cv[0].getContext("2d");
+            if (!ctx) return;
+
+            // draw set
+            p=Math.floor(p);
+            var pImg=$imageList[p];
+            ctx.clearRect(drawX,drawY,chipWidth,chipHeight);
+            if (pImg) {
+                ctx.save();
+                ctx.drawImage(
+                pImg.image, pImg.x, pImg.y, pImg.width, pImg.height,
+                drawX, drawY, chipWidth, chipHeight);
+                ctx.restore();
+            }
+            
+            // draw setOn
+            onP=Math.floor(onP);
+            pImg=$imageList[onP];
+            if (pImg) {
+                ctx.save();
+                ctx.drawImage(
+                pImg.image, pImg.x, pImg.y, pImg.width, pImg.height,
+                drawX, drawY, chipWidth, chipHeight);
+                ctx.restore();
+            }
+        }
+    }
+}
 \set(setCol,setRow,p){
     if(setCol>=col || setRow>=row || setCol<0 || setRow<0) return;
-    mapTable[setRow][setCol]=p;
-    //mapOnTable[setRow][setCol]=-1;
-    ctx=buf[0].getContext("2d");
-    if (!ctx) return;
-    p=Math.floor(p);
-    pImg=$imageList[p];
-    if (!pImg) {
-        ctx.clearRect(setCol*chipWidth,setRow*chipHeight,chipWidth,chipHeight);
-        return;
-    }
-    ctx.clearRect(setCol*chipWidth,setRow*chipHeight,chipWidth,chipHeight);
-    ctx.save();
-    //console.log("SET",    pImg.image, pImg.x, pImg.y, pImg.width, pImg.height,
-    //    setCol*chipWidth, setRow*chipHeight, chipWidth, chipHeight);
-    ctx.drawImage(
-    pImg.image, pImg.x, pImg.y, pImg.width, pImg.height,
-    setCol*chipWidth, setRow*chipHeight, chipWidth, chipHeight);
-    ctx.restore();
+    setAll(setCol,setRow,p,mapOnTable[setRow][setCol]);
 }
-\setOn(setCol,setRow,p){
+\setOn(setCol,setRow,onP){
     if(setCol>=col || setRow>=row || setCol<0 || setRow<0) return;
-    set(setCol,setRow,mapTable[setRow][setCol]);
-    mapOnTable[setRow][setCol]=p;
-    ctx=buf[0].getContext("2d");
-    p=Math.floor(p);
-    pImg=$imageList[p];
-    if (!pImg) return;
-    ctx.save();
-    ctx.drawImage(
-    pImg.image, pImg.x, pImg.y, pImg.width, pImg.height,
-    setCol*chipWidth, setRow*chipHeight, chipWidth, chipHeight);
-    ctx.restore();
+    setAll(setCol,setRow,mapTable[setRow][setCol],onP);
 }
 \setOnAt(setX,setY,p){
     setOn(Math.floor((setX-sx)/chipWidth),Math.floor((setY-sy)/chipHeight),p);
@@ -156,11 +194,209 @@ native console;
     sy=-scrollY;
 }
 \draw(ctx) {
-    pImg=buf[0];
+    var lay=$Screen.findLayer(layer);
+    //console.log("lay",lay);
+    var lsx=lay.spx; // Screen pivot x
+    var lsy=lay.spy; // Screen pivot y
+    var lwx=lay.wpx; // World pivot x
+    var lwy=lay.wpy; // World pivot y
+    var ls=(typeof lay.scale=="number")? lay.scale : 1; // layer scale
+    var lr=(typeof lay.rotation=="number")? lay.rotation : 0; // layer rotation
+    var hs=bufAry.length;
+    var sum=0;
     ctx.save();
-    ctx.globalAlpha=alpha/255;
-    ctx.drawImage(
-    pImg, 0, 0,col*chipWidth, row*chipHeight,
-    sx, sy, col*chipWidth, row*chipHeight);
+    // if (lr==0) { // layer rotation == 0
+        for(var j=0;j<hs;j++){
+            var ws=bufAry[j].length;
+            for(var i=0;i<ws;i++){
+                var pCv=bufAry[j][i];
+                if (!pCv) return;
+                var pCtx=pCv[0];
+                if (!pCtx) return;
+                var dx=sx+i*bufSplit; // Split Map x
+                var dy=sy+j*bufSplit; // Split Map y
+                var dw=pCtx.width;    // Split Map width
+                var dh=pCtx.height;   // Split Map height
+                var mx1=lsx+(dx-lwx)*ls;    // Map draw x1 (left)
+                var my1=lsy+(dy-lwy)*ls;    // Map draw y1 (top)
+                var mx2=lsx+(dx-lwx+dw)*ls; // Map draw x2 (right)
+                var my2=lsy+(dy-lwy+dh)*ls; // Map draw y2 (buttom)
+                if(lr!=0 || (0<=mx2 && mx1<$screenWidth && 0<=my2 && my1<$screenHeight)){
+                    ctx.globalAlpha=alpha/255;
+                    ctx.drawImage(
+                    pCtx, 0, 0, dw, dh,
+                    dx, dy, dw, dh);
+                    // if ((i+j)%2==1) {
+                    //     var ga = ctx.globalAlpha;
+                    //     var fi = ctx.fillStyle;
+                    //     ctx.globalAlpha = 0.125;
+                    //     ctx.fillStyle = "rgb(255, 255, 0)";
+                    //     ctx.fillRect(dx, dy, dw, dh);
+                    //     ctx.globalAlpha = ga;
+                    //     ctx.fillStyle = fi;
+                    // }
+                    sum++;
+                }
+            }
+        }
+    // } else { // layer rotation != 0
+    //     // var lxyAry = [
+    //     //     -lsx, -lsy, $screenWidth
+    //     // ];
+    //     var msin=sin(lr);
+    //     var mcos=cos(lr);
+    //     for(var j=0;j<hs;j++){
+    //         var ws=bufAry[j].length;
+    //         for(var i=0;i<ws;i++){
+    //             var pCv=bufAry[j][i];
+    //             if (!pCv) return;
+    //             var pCtx=pCv[0];
+    //             if (!pCtx) return;
+    //             var dx=sx+i*bufSplit; // Split Map x
+    //             var dy=sy+j*bufSplit; // Split Map y
+    //             var dw=pCtx.width;    // Split Map width
+    //             var dh=pCtx.height;   // Split Map height
+    //             var mx1=(dx-lwx)*ls;    // Map draw x1 (left)
+    //             var my1=(dy-lwy)*ls;    // Map draw y1 (top)
+    //             var mx2=(dx-lwx+dw)*ls; // Map draw x2 (right)
+    //             var my2=(dy-lwy+dh)*ls; // Map draw y2 (buttom)
+    //             var txy=[ // temp Map draw x,y
+    //                 mx1, my1,
+    //                 mx2, my1,
+    //                 mx2, my2,
+    //                 mx1, my2,
+    //             ];
+    //             var mxy=[];
+    //             for(var k=0;k<4;k++){ // Map x,y rotation
+    //                 mxy.push(txy[k]*mcos+txy[k+1]*msin+lsx);
+    //                 mxy.push(txy[k+1]*mcos+txy[k]*msin+lsy);
+    //             }
+    //             if(0+16<=mx2 && mx1<$screenWidth-16 && 0+16<=my2 && my1<$screenHeight-16){
+    //                 ctx.globalAlpha=alpha/255;
+    //                 ctx.drawImage(
+    //                 pCtx, 0, 0, dw, dh,
+    //                 dx, dy, dw, dh);
+    //                 if ((i+j)%2==1) {
+    //                     var ga = ctx.globalAlpha;
+    //                     var fi = ctx.fillStyle;
+    //                     ctx.globalAlpha = 0.125;
+    //                     ctx.fillStyle = "rgb(255, 255, 0)";
+    //                     ctx.fillRect(dx, dy, dw, dh);
+    //                     ctx.globalAlpha = ga;
+    //                     ctx.fillStyle = fi;
+    //                 }
+    //                 sum++;
+    //             }
+    //         }
+    //     }
+    // }
     ctx.restore();
+    // console.log("draw",
+    // "lsx:",lsx,
+    // "lsy:",lsy,
+    // "lwx:",lwx,
+    // "lwy:",lwy,
+    // "ls:",ls,
+    // "lr:",lr,
+    // "sum:",sum);
 }
+
+// \draw2(ctx) {
+//     var lay=$Screen.findLayer(layer);
+//     //console.log("lay",lay);
+//     var lsx=lay.spx; // Screen pivot x
+//     var lsy=lay.spy; // Screen pivot y
+//     var lwx=lay.wpx; // World pivot x
+//     var lwy=lay.wpy; // World pivot y
+//     var ls=(typeof lay.scale=="number")? lay.scale : 1; // layer scale
+//     var lr=(typeof lay.rotation=="number")? lay.rotation : 0; // layer rotation
+//     var hs=bufAry.length;
+//     var ws=hs>0? bufAry[0].length : 0;
+//     var sum=0;
+//     ctx.save();
+//     if (lr==0) { // layer rotation == 0
+//         var i1=floor(((lwx+sx)/ls-lsx)/bufSplit);
+//         var j1=floor(((lwy+sy)/ls-lsy)/bufSplit);
+//         var i2=floor(((lwx+sx+$screenWidth)/ls-lsx)/bufSplit);
+//         var j2=floor(((lwy+sy+$screenHeight)/ls-lsy)/bufSplit);
+//         i1 = i1<0 ? 0 : i1>=ws ? ws-1 : i1;
+//         j1 = j1<0 ? 0 : j1>=hs ? hs-1 : j1;
+//         i2 = i2<0 ? 0 : i2>=ws ? ws-1 : i2;
+//         j2 = j2<0 ? 0 : j2>=hs ? hs-1 : j2;
+//         for(var j=j1;j<=j2;j++){
+//             for(var i=i1;i<=i2;i++){
+//                 var pImg=bufAry[j][i];
+//                 if (!pImg) return;
+//                 var pCtx=pImg[0];
+//                 if (!pCtx) return;
+//                 var dx=sx+i*bufSplit; // layer draw x
+//                 var dy=sy+j*bufSplit; // layer draw y
+//                 var dw=pImg.width;    // layer draw width
+//                 var dh=pImg.height;   // layer draw height
+//                 var mx1=lsx+(-lwx+dx)*ls;    // Map draw x1 (left)
+//                 var my1=lsy+(-lwy+dy)*ls;    // Map draw y1 (top)
+//                 var mx2=lsx+(-lwx+dx+dw)*ls; // Map draw x2 (right)
+//                 var my2=lsy+(-lwy+dy+dh)*ls; // Map draw y2 (buttom)
+//                 if(0+16<=mx2 && mx1<$screenWidth-16 && 0+16<=my2 && my1<$screenHeight-16){
+//                     ctx.globalAlpha=alpha/255;
+//                     ctx.drawImage(
+//                     pCtx, 0, 0, dw, dh,
+//                     dx, dy, dw, dh);
+//                     // if ((i+j)%2==1) {
+//                     //     var ga = ctx.globalAlpha;
+//                     //     var fi = ctx.fillStyle;
+//                     //     ctx.globalAlpha = 0.125;
+//                     //     ctx.fillStyle = "rgb(255, 255, 0)";
+//                     //     ctx.fillRect(dx, dy, dw, dh);
+//                     //     ctx.globalAlpha = ga;
+//                     //     ctx.fillStyle = fi;
+//                     // }
+//                     sum++;
+//                 }
+//             }
+//         }
+//     } else { // layer rotation != 0
+//         // var lxyAry = [
+//         //     -lsx, -lsy, $screenWidth
+//         // ];
+//         // for(var j=0;j<hs;j++){
+//         //     var ws=bufAry[j].length;
+//         //     for(var i=0;i<ws;i++){
+//         //         var pImg=bufAry[j][i][0];
+//         //         var dx=sx+i*bufSplit; // layer draw x
+//         //         var dy=sy+j*bufSplit; // layer draw y
+//         //         var dw=pImg.width;    // layer draw width
+//         //         var dh=pImg.height;   // layer draw height
+//         //         var mx1=lsx+(-lwx+dx)*ls;    // Map draw x1
+//         //         var my1=lsy+(-lwy+dy)*ls;    // Map draw y1
+//         //         var mx2=lsx+(-lwx+dx+dw)*ls; // Map draw x2
+//         //         var my2=lsy+(-lwy+dy+dh)*ls; // Map draw y2
+//         //         if(0+16<=mx2 && mx1<$screenWidth-16 && 0+16<=my2 && my1<$screenHeight-16){
+//         //             ctx.globalAlpha=alpha/255;
+//         //             ctx.drawImage(
+//         //             pImg, 0, 0, dw, dh,
+//         //             dx, dy, dw, dh);
+//         //             if ((i+j)%2==1) {
+//         //                 var ga = ctx.globalAlpha;
+//         //                 var fi = ctx.fillStyle;
+//         //                 ctx.globalAlpha = 0.125;
+//         //                 ctx.fillStyle = "rgb(255, 255, 0)";
+//         //                 ctx.fillRect(dx, dy, dw, dh);
+//         //                 ctx.globalAlpha = ga;
+//         //                 ctx.fillStyle = fi;
+//         //             }
+//         //             sum++;
+//         //         }
+//         //     }
+//         // }
+//     }
+//     ctx.restore();
+//     console.log("draw",
+//     "lsx:",lsx,
+//     "lsy:",lsy,
+//     "lwx:",lwx,
+//     "lwy:",lwy,
+//     "ls:",ls,
+//     "lr:",lr,
+//     "sum:",sum);
+// }


### PR DESCRIPTION
- MapのCanvasが1024px以上になると1024pxごとに分割してCanvas作成・表示
  - iOSでMapが表示されない問題（4096px超えると表示されない）が改善された
  - iOSでMapのCanvasが4096pxに近いと処理落ちする問題が軽量化された
- 分割したCanvasは画面外にあるとき非表示（$Screen.scrollTo()でrotation==0の場合）
- load処理を軽減（set()とsetOn()の重複処理を改善）

まだ未対応（後でやります）
- $Screen.scrollTo()でrotation!=0の場合の、画面外Canvasを非表示にする処理
- 画面外Canvasの非表示処理の軽量化
