### PR TITLE
Fix npm run build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ www/js/g2/*.map
 www/js/g2/send.bat
 www/html/BuilderWorker.js
 node_modules/
-/nwjs-sdk-*.zip
+/download/*

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ www/js/g2/*.map
 www/js/g2/send.bat
 www/html/BuilderWorker.js
 node_modules/
+/nwjs-sdk-*.zip

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install
 npm run build
 ~~~
 
-- To run as a native application, download [nw.js](https://nwjs.io/) and add following files in /path/to/Tonyu2/
+- To run as a native application, download [nw.js](https://nwjs.io/) and add following files in /path/to/Tonyu2/, you can use `npm run runtime`
 ~~~
 d3dcompiler_47.dll
 ffmpeg.dll

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Windows 7/8/10
 - Clone [tonyu2-compiler](https://github.com/hoge1e3/tonyu2-compiler/) repository to the same directory.
 - Run the following node.js command.
 ~~~
+cd tonyu2-compiler
+npm install
+cd ../Tonyu2
 npm install
 npm run build
 ~~~

--- a/build/build.js
+++ b/build/build.js
@@ -7,10 +7,10 @@ const cmds = [
     "..\\node_modules\\.bin\\r_js -o editor_build.js",
     "..\\node_modules\\.bin\\r_js -o run2_build.js",
     "..\\node_modules\\.bin\\r_js -o run1_build.js",
-    "..\\node_modules\\.bin\\r_js -o sysdebug_build.js",
+    "..\\node_modules\\.bin\\r_js -o sysdebug_build.js"
 ];
 
-for (var cmd of cmds) {
+for (const cmd of cmds) {
     console.log(cmd);
     const stdout = execSync(cmd, {cwd: __dirname});
     // console.log(stdout.toString());

--- a/build/build_kernel.js
+++ b/build/build_kernel.js
@@ -5,7 +5,7 @@ const cmds = [
     "node ..\\..\\tonyu2-compiler\\index.js ..\\www\\Kernel\\"
 ];
 
-for (var cmd of cmds) {
+for (const cmd of cmds) {
     console.log(cmd);
     const stdout = execSync(cmd, {cwd: __dirname});
     // console.log(stdout.toString());

--- a/build/copy_from_compiler.js
+++ b/build/copy_from_compiler.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require("fs");
 
 const src = "../tonyu2-compiler";
 const dist = "www";

--- a/build/copy_from_compiler.js
+++ b/build/copy_from_compiler.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+
+const src = "../tonyu2-compiler";
+const dist = "www";
+const paths = [
+    {src:src+"/test/fixture/BuilderClient4Sys.js", dist:dist+"/js/lang/BuilderClient4Sys.js"},
+    {src:src+"/test/fixture/BuilderWorker.js", dist:dist+"/BuilderWorker.js"},
+    {src:src+"/test/fixture/TonyuRuntime.js", dist:dist+"/js/runtime/TonyuRuntime.js"}
+];
+
+for (const p of paths) {
+    console.log(p.src, p.dist);
+    fs.copyFileSync(p.src, p.dist);
+}
+
+// SRC=../tonyu2-compiler
+// DST=www
+
+// #pre-built(browserified)
+// cp $SRC/test/fixture/BuilderClient4Sys.js $DST/js/lang/
+// cp $SRC/test/fixture/BuilderWorker.js $DST/
+// cp $SRC/test/fixture/TonyuRuntime.js $DST/js/runtime/

--- a/build/dl_nw.js
+++ b/build/dl_nw.js
@@ -1,0 +1,140 @@
+const https = require("https");
+const fs = require("fs");
+const {performance} = require("perf_hooks");
+// const zlib = require("zlib");
+// const stream = require("stream");
+
+dlMain().then(() => {
+    console.log("Success dl_nw.js");
+});
+
+async function dlMain() {
+    const verJson = await getJson("https://nwjs.io/versions.json");
+    // console.log(verJson);
+
+    let version = verJson.stable; // EX) "v0.48.1"
+    let osFile = "win-x64";
+    let [url, fileName] = getURL(version, osFile);
+    // fileName = ""+fileName;
+    
+    console.log("url  : "+url);
+    console.log("file : "+fileName);
+
+    await dlNw(url, fileName);
+    // await unzip(fileName, "nwdir");
+}
+
+function getURL(version, osFile) {
+    const fileName = "nwjs-sdk-"+version+"-"+osFile+".zip";
+    const url = "https://dl.nwjs.io/"+version+"/"+fileName;
+    return [url, fileName];
+}
+
+function getJson(url) {
+    return new Promise(resolve => {
+        const data = [];
+        https.get(url, (res) => {
+            res.on("data", (chunk) => {
+                data.push(chunk);
+            }).on("end", () => {
+                const d = Buffer.concat(data);
+                const j = JSON.parse(d);
+                resolve(j);
+            });
+        });
+    });
+}
+
+function dlNw(url, fileName) {
+    return new Promise((resolve, reject) => {
+        const file = fs.createWriteStream(fileName);
+        const req = https.get(url, (res) => {
+            // console.log("statusCode:", res.statusCode);
+            // console.log("headers:", res.headers);
+            let size = parseInt(res.headers["content-length"]);
+            const progress = new Progress(size, (per, cnt, size, cntsecdisp) => {
+                // process.stdout.clearLine();
+                process.stdout.cursorTo(0);
+                process.stdout.write("["+per+"%]  "+dispSize(cnt)+" / "+dispSize(size)+"  ("+dispSize(cntsecdisp)+"/sec)         ");
+            });
+            res.on("data", (d) => {
+                progress.notice(d.length);
+            });
+            res.pipe(file);
+            file.on("finish", function() {
+                file.close();
+                process.stdout.clearLine();
+                process.stdout.cursorTo(0);
+                console.log("downloaded!");
+                resolve();
+            });
+        });
+        req.on("error", (e) => {
+            console.error(e);
+            reject();
+        });
+        req.end();
+    });
+}
+
+// function unzip(zipFileName, fileName) {
+//     return new Promise((resolve, reject) => {
+//         console.log("zipFileName  : "+zipFileName);
+//         console.log("fileName : "+fileName);
+
+//         const unzip = zlib.createUnzip();
+//         const src = fs.createReadStream(zipFileName);
+//         const dist = fs.createWriteStream(fileName);
+        
+//         let size = fs.statSync(zipFileName).size;
+//         const progress = new Progress(size, (per, cnt, size, cntsecdisp) => {
+//             // process.stdout.clearLine();
+//             process.stdout.cursorTo(0);
+//             process.stdout.write("["+per+"%]  "+dispSize(cnt)+" / "+dispSize(size)+"  ("+dispSize(cntsecdisp)+"/sec)         ");
+//         });
+//         dist.on("data", (d) => {
+//             progress.notice(d.length);
+//         });
+//         dist.on("finish", (err) => {
+//             process.stdout.clearLine();
+//             process.stdout.cursorTo(0);
+//             console.log("finish Unzip");
+//             resolve();
+//         });
+
+//         stream.pipeline(src, unzip, dist, (err) => {
+//             console.error("error Unzip:", err);
+//         });
+//     })
+// }
+
+class Progress {
+    constructor(size, fnDisp) {
+        this.cnt = 0;
+        this.size = size;
+        this.cntsec = 0;
+        this.cntsecdisp = 0;
+        this.t1 = performance.now();
+        this.fnDisp = fnDisp;
+    }
+    notice(dlen) {
+        const now = performance.now();
+        this.cnt += dlen;
+        this.cntsec += dlen;
+        const upMs = 500;
+        if (now - this.t1 >= upMs) {
+            this.t1 += upMs;
+            this.cntsecdisp = this.cntsec * 1000/upMs;
+            this.cntsec = 0;
+            const per = parseInt(this.cnt/this.size*100);
+            this.fnDisp(per, this.cnt, this.size, this.cntsecdisp);
+        }
+    }
+}
+
+function dispSize(b) {
+    return b < 1024 ? b+" B" : 
+        b < 1048576 ? parseInt(b/1024)+" KiB" :
+        b < 1073741824 ? parseInt(b/1048576)+" MiB" :
+        parseInt(b/1073741824)+" GiB";
+}

--- a/build/dl_nw.js
+++ b/build/dl_nw.js
@@ -22,6 +22,8 @@ async function dlMain() {
 
     if (!fs.existsSync(zipFileName)) {
         await downloadNw(url, zipFileName);
+    } else {
+        console.log("cache zip");
     }
     await unzip(zipFileName, workDir);
     await copyFile(dirName, workDir);

--- a/copyFromCompiler.sh
+++ b/copyFromCompiler.sh
@@ -1,7 +1,0 @@
-SRC=../tonyu2-compiler
-DST=www
-
-#pre-built(browserified)
-cp $SRC/test/fixture/BuilderClient4Sys.js $DST/js/lang/
-cp $SRC/test/fixture/BuilderWorker.js $DST/
-cp $SRC/test/fixture/TonyuRuntime.js $DST/js/runtime/

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,51 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "adm-zip": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "dev": true
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "commander": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
       "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
     },
     "requirejs": {
       "version": "2.3.6",
@@ -31,6 +71,12 @@
         "commander": "~2.13.0",
         "source-map": "~0.6.1"
       }
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build": "npm run build:copy && npm run build:g2 && npm run build:kernel",
     "build:copy": "node build/copy_from_compiler.js",
     "build:g2": "node build/build.js",
-    "build:kernel": "node build/build_kernel.js"
+    "build:kernel": "node build/build_kernel.js",
+    "dl:nw": "node build/dl_nw.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {},
   "scripts": {
     "build": "npm run build:copy && npm run build:g2 && npm run build:kernel",
-    "build:copy": "sh copyFromCompiler.sh",
+    "build:copy": "node build/copy_from_compiler.js",
     "build:g2": "node build/build.js",
     "build:kernel": "node build/build_kernel.js"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     ]
   },
   "devDependencies": {
+    "adm-zip": "^0.4.16",
+    "fs-extra": "^9.0.1",
     "requirejs": "^2.3.6",
     "uglify-es": "^3.3.9"
   },
@@ -27,7 +29,7 @@
     "build:copy": "node build/copy_from_compiler.js",
     "build:g2": "node build/build.js",
     "build:kernel": "node build/build_kernel.js",
-    "dl:nw": "node build/dl_nw.js"
+    "runtime": "node build/dl_nw.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- copyFromCompiler.shをnodejsに統一するため削除し、nodejs版のcopy_from_compiler.jsを作成
- tonyu2-compilerはクローン後初回はnpm installしないと、Tonyu2側のnpm run buildで失敗するためREADME.mdのHow to buildの記載を修正
- nodejsでTonyu2ランタイムを準備できるようにしようとして、NW.js最新バージョンのzipダウンロードまで作った