### PR TITLE
fix Actor3D $Screen.resize x,y

### DIFF
--- a/www/Kernel/graphics/Layer3D.tonyu
+++ b/www/Kernel/graphics/Layer3D.tonyu
@@ -10,6 +10,8 @@ var spx,spy,camera,screen;
     spy=spy||$screenHeight/2;
 }
 \draw(c2) {
+    spx=$screenWidth/2;
+    spy=$screenHeight/2;
     var c3=new Context3D{camera};
     group.draw3D(c3);
     var s2ds=c3.sprites2D.sort \(a,b) {
@@ -24,6 +26,8 @@ var spx,spy,camera,screen;
     c2.restore();
 }
 \world2screen(obj) {// world<=>group
+    spx=$screenWidth/2;
+    spy=$screenHeight/2;
     var r=camera.to2D(camera.transform.inverse.childToSibling(obj));
     r.x+=spx;
     r.y+=spy;


### PR DESCRIPTION
 $Screen.resize()した後にActor3Dの座標がずれる問題を修正

・resizeで画面を大きくしたときに、中央のActor3Dが左上に寄ってしまう問題を修正
・雑な修正
・resizeで画面を大きくしても、Cameraの画角が狭いままなので、そこも修正が必要そう