### PR TITLE
playSE()のreturn忘れ修正、iPadOS判定、iOS画面回転時のresizeされないのを修正

### DIFF
--- a/www/Kernel/util/Navigator.tonyu
+++ b/www/Kernel/util/Navigator.tonyu
@@ -3,6 +3,7 @@
 // http://qiita.com/nightyknite/items/b2590a69f2e0135756dc
 
 native navigator;
+native document;
 
 \getUserAgent() {
     return navigator.userAgent;
@@ -10,9 +11,10 @@ native navigator;
 
 \isTablet() {
     var u = getUserAgent().toLowerCase();
+    var isIPad = u.indexOf("ipad") != -1 || (u.indexOf("macintosh") != -1 && document.ontouchend); // iPadOS(iOS13.0以降)の判定に対応
     return (
     (u.indexOf("windows") != -1 && u.indexOf("touch") != -1 && u.indexOf("tablet pc") == -1)
-    || u.indexOf("ipad") != -1
+    || isIPad != -1
     || (u.indexOf("android") != -1 && u.indexOf("windows") == -1 && u.indexOf("mobile") == -1)
     || (u.indexOf("firefox") != -1 && u.indexOf("tablet") != -1)
     || u.indexOf("kindle") != -1 || u.indexOf("silk") != -1
@@ -48,9 +50,10 @@ native navigator;
 
 \isIOS() {
     var u = getUserAgent().toLowerCase();
+    var isIPad = u.indexOf("ipad") != -1 || (u.indexOf("macintosh") != -1 && document.ontouchend); // iPadOS(iOS13.0以降)の判定に対応
     return (
     u.indexOf("iphone") != -1
-    || u.indexOf("ipad") != -1
+    || isIPad
     || u.indexOf("ipod") != -1
     );
 }

--- a/www/js/lib/T2MediaLib.js
+++ b/www/js/lib/T2MediaLib.js
@@ -410,7 +410,7 @@ var T2MediaLib = (function(){
 
     // SEメソッド郡 //
     T2MediaLib.prototype.playSE = function(idx, vol, pan, rate, offset, loop, loopStart, loopEnd,start,duration) {//add start,duration by @hoge1e3
-        this._playSE(idx,
+        return this._playSE(idx,
             vol * this.seMasterVolume * this.masterVolume,
             pan, rate, offset, loop, loopStart, loopEnd,start,duration);
     }

--- a/www/js/runtime/runScript_common.js
+++ b/www/js/runtime/runScript_common.js
@@ -18,10 +18,18 @@ define(["root","WebSite"], function (root,WebSite) {
 
             var u = navigator.userAgent.toLowerCase();
             if (doResize==null) {
-                doResize=(u.indexOf("iphone") == -1 &&
-                    u.indexOf("ipad") == -1 &&
-                    u.indexOf("ipod") == -1
-                ) && (!window.parent || window === window.parent);
+                doResize = true;
+                // "…(iPhone; CPU iPhone OS 15_4 like Mac OS X)…"の"15"を抜き出す
+                var iOSver = parseInt(u.substring(u.lastIndexOf(" ", u.indexOf("_")-1)+1, u.indexOf("_"))); // iOSのバージョン
+                if (isNaN(iOSver)) iOSver = 15;
+
+                // iOSの12まではiframe内でresizeするとバグるので無効化(heightが永遠と伸びるバグ)
+                if ((u.indexOf("iphone") != -1 || u.indexOf("ipad") != -1 || u.indexOf("ipod") != -1) &&
+                    iOSver <= 12 &&
+                    (!window.parent || window != window.parent) // iframe時(一応window.parentが有効かもチェック)
+                ) {
+                    doResize = false;
+                }
                 if (WebSite.doResize!=null) doResize=WebSite.doResize;
             }
             if (doResize) {


### PR DESCRIPTION
- stopSE()が効かなくなってしまうので修正
- iPadOS(iOS13.0以降)の判定に対応
- iOSで画面回転させても画面がresizeされないので修正

そういえば、jsファイルを変更しているので`npm run build`が必要です。